### PR TITLE
Add `mdast-util-to-string` as a dependency

### DIFF
--- a/dist/alphabetical-list-items.js
+++ b/dist/alphabetical-list-items.js
@@ -1,8 +1,7 @@
 'use strict';
 
 var visit = require('unist-util-visit');
-var strip = require('strip-markdown');
-var remark = require('remark').use(strip);
+var toString = require('mdast-util-to-string');
 
 function normalize(text) {
   var removeAtBeginning = /^(\.|\-|\_|\(|《|\"|\')*/;
@@ -13,7 +12,6 @@ function normalize(text) {
 
 function alphaCheck(ast, file, language, done) {
   language || (language = 'en-US');
-  var contents = file.toString();
 
   visit(ast, 'list', function (node) {
     var items = node.children;
@@ -22,9 +20,7 @@ function alphaCheck(ast, file, language, done) {
 
     items.forEach(function (item) {
       if (item.children.length) {
-        var lineStartOffset = item.children[0].children[0].position.start.offset;
-        var lineEndOffset = item.children[0].children[item.children[0].children.length - 1].position.end.offset;
-        var text = normalize(remark.process(contents.slice(lineStartOffset, lineEndOffset)));
+        var text = normalize(toString(item));
         var line = item.position.start.line;
         var comp = new Intl.Collator(language).compare(lastText, text);
         if (comp > 0) {

--- a/lib/alphabetical-list-items.js
+++ b/lib/alphabetical-list-items.js
@@ -1,6 +1,5 @@
 const visit = require('unist-util-visit');
-const strip = require('strip-markdown');
-const remark = require('remark').use(strip);
+const toString = require('mdast-util-to-string');
 
 function normalize(text) {
   const removeAtBeginning = /^(\.|\-|\_|\(|《|\"|\')*/;
@@ -13,7 +12,6 @@ function normalize(text) {
 
 function alphaCheck(ast, file, language, done) {
   language || (language = 'en-US');
-  const contents = file.toString();
 
   visit(ast, 'list', (node) => {
     const items = node.children;
@@ -22,9 +20,7 @@ function alphaCheck(ast, file, language, done) {
 
     items.forEach((item) => {
       if (item.children.length) {
-        const lineStartOffset = item.children[0].children[0].position.start.offset;
-        const lineEndOffset = item.children[0].children[item.children[0].children.length - 1].position.end.offset;
-        const text = normalize(remark.process(contents.slice(lineStartOffset, lineEndOffset)));
+        const text = normalize(toString(item));
         const line = item.position.start.line;
         const comp = new Intl.Collator(language).compare(lastText, text);
         if (comp > 0) {

--- a/package.json
+++ b/package.json
@@ -9,8 +9,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "remark": "^3.0.0",
-    "strip-markdown": "^0.3.1",
+    "mdast-util-to-string": "^1.0.0",
     "unist-util-visit": "^1.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
...and remove `remark`, `strip-markdown`.

Reason for this is that it’s a lot faster to just stringify the `item`.
Also: there weren’t any tests by I checked it on:

```md
*   foo
*   bar
*   baz
```

...and the result were still OK :smile: 