### PR TITLE
enhacement: strip LTM and RTM entities when normalize text

### DIFF
--- a/lib/alphabetical-list-items.js
+++ b/lib/alphabetical-list-items.js
@@ -3,8 +3,8 @@ const visit = require('unist-util-visit');
 const toString = require('mdast-util-to-string');
 
 function normalize(text) {
-  const removeAtBeginning = /^([-._(《"'])*/;
-  const removeInside = /[,:]/;
+  const removeAtBeginning = /^([-._(《"'\u200e\u200f])*/;
+  const removeInside = /[,:\u200e\u200f]/;
   const replaceWithSpace = /-/;
   return text.toLowerCase()
     .trim()


### PR DESCRIPTION
Text to direction magic marks should be stripped to support bidirectional text alphabetization (https://en.wikipedia.org/wiki/Bidirectional_text) in Arabic, Persian an Hebrew languages (at least)

Via https://github.com/EbookFoundation/free-programming-books/issues/6714 and https://github.com/EbookFoundation/free-programming-books/pull/6715/#issuecomment-1036637292